### PR TITLE
added session timeout

### DIFF
--- a/api/db/database.py
+++ b/api/db/database.py
@@ -7,7 +7,9 @@ from sqlalchemy.orm import sessionmaker
 
 SQLALCHEMY_DATABASE_URL=f"mysql+pymysql://{MYSQL_USER}:{MYSQL_PASSWORD}@{MYSQL_HOST}:{MYSQL_PORT}/{MYSQL_DB}"
 
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(SQLALCHEMY_DATABASE_URL,
+                        pool_recycle=3600,
+                        pool_pre_ping=True) ### Thank you Gemini for this fix! The error was likely due to a timeout on the SQL server-side. -JT
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
Looks like the server refusal was due to the API using expired connections. I added in 2 things:

The API will refresh the connection after 1 hour
The API will ping the database before attempting to query it. If the ping fails, it will refresh the connection and try again.
A big thank you to Gemini for listening to my woes and providing insight.